### PR TITLE
fix: follow `patch-7.4.1168` changes

### DIFF
--- a/autoload/fern/renderer/nvim_devicons.vim
+++ b/autoload/fern/renderer/nvim_devicons.vim
@@ -84,7 +84,7 @@ endfunction
 function! s:get_node_symbol(node, options) abort
   if a:node.status is# s:STATUS_NONE
     let symbol = a:options.leaf_symbol . luaeval("require'nvim-web-devicons'.get_icon(_A[1], _A[2])",[a:node.label, fnamemodify(a:node.bufname, ":e")])
-    if symbol == 'null'
+    if symbol ==# v:null
       let symbol = ''
     endif
   elseif a:node.status is# s:STATUS_COLLAPSED


### PR DESCRIPTION
By [vim-patch:7.4.1168](https://github.com/neovim/neovim/pull/19645), `v:null ==# 'null'` now evaluates to `false`, but `v:null ==# v:null` is works unchanged.